### PR TITLE
Don't use rpath in the Python bindings.

### DIFF
--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -6,7 +6,7 @@ libemu = Extension('libemu',
                     sources = ['libemu_module.c'],
                     include_dirs = ['../../include'],
                     library_dirs = ['../../src/.libs'],
-                    extra_link_args=['-Wl,-rpath=@LIBDIR@'],
+                    #extra_link_args=['-Wl,-rpath=@LIBDIR@'],
                     libraries = ['emu'],
                     )
 


### PR DESCRIPTION
This patch is from Debian package 
https://packages.debian.org/search?searchon=sourcenames&keywords=libemu
Description: Don't use rpath in the Python bindings.
The Python bindings insist on using an rpath on /usr/lib.  Nuke it.
Author: David Martínez Moreno <ender@debian.org>
Forwarded: no
Last-Update: 2012-10-01