### PR TITLE
Allow installation of the python binding to a DESTDIR

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -6,7 +6,7 @@ all:
 	python setup.py build
 
 install: all
-	python setup.py install
+	python setup.py install --prefix=$(DESTDIR)$(prefix)
 
 clean:
 	python setup.py clean


### PR DESCRIPTION
Allowing DESTDIR in the makefile makes the packaging easier as it makes it possible to install the files as intended to some clean sandbox, instead of installing to the living system  - such as "make install DESTDIR=/buildroot". This is common practice followed by GNU tools like automake/autoconf/configure etc.

This patch is from libemu Debian package - libemu-02_python_install_dir.patch
https://packages.debian.org/search?searchon=sourcenames&keywords=libemu

Description: Force installation of the Python module in debian/tmp.
Debian-centric patch to force the installation of this module into debian/tmp.
Author: David Martínez Moreno <ender@debian.org>
Forwarded: not-needed
Last-Update: 2012-10-12