### PR TITLE
fix the memory leak in emu_memory_free

### DIFF
--- a/src/emu_memory.c
+++ b/src/emu_memory.c
@@ -171,16 +171,26 @@ void emu_memory_free(struct emu_memory *m)
 	int i, j;
 	
 	emu_breakpoint_free(m->breakpoint);
-	
+
 	for( i = 0; i < (1 << (32 - PAGESET_BITS - PAGE_BITS)); i++ )
 	{
 		if( m->pagetable[i] != NULL )
 		{
 			for( j = 0; j < PAGESET_SIZE; j++ )
-				if( m->pagetable[i][j] != NULL )
+				if( m->pagetable[i][j] != NULL ) {
 					free(m->pagetable[i][j]);
-			
+					m->pagetable[i][j] = NULL;
+				}
+			//free(m->pagetable[i]);
+		}
+	}
+
+	for( i = 0; i < (1 << (32 - PAGESET_BITS - PAGE_BITS)); i++ )
+	{
+		if( m->pagetable[i] != NULL )
+		{
 			free(m->pagetable[i]);
+			m->pagetable[i] = NULL;
 		}
 	}
 	


### PR DESCRIPTION
Hello,
this patch from Angelo Dell'Aera <buffer@olografix.org> should be fixing memory leak in the emu_memory_free function.

https://github.com/buffer/libemu/commit/9256d8dc460b15a1c05d19b2fd277939602145e1.patch