### PR TITLE
Add option to parametrize building python binary for the build

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -1,15 +1,16 @@
 # $Id$
 
 AUTOMAKE_OPTIONS = foreign
+PYTHON = python
 
 all:
-	python setup.py build
+	$(PYTHON) setup.py build
 
 install: all
-	python setup.py install
+	$(PYTHON) setup.py install --prefix=$(DESTDIR)$(prefix)
 
 clean:
-	python setup.py clean
+	$(PYTHON) setup.py clean
 
 dist-clean: clean
 


### PR DESCRIPTION
Add option to parametrize building python binary for the build
of the python binding. As Fedora is approaching the switch from
python2 to python3 it removed the default link from python to
python2 runtime binary. This patch will allow to specify the
python binary explicitly during the build such as:
make build PYTHON=python2